### PR TITLE
sc-im depends on libxls to get Excel reading

### DIFF
--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -18,6 +18,7 @@ class ScIm < Formula
   end
 
   depends_on "libxlsxwriter"
+  depends_on "libxls"
   depends_on "libxml2"
   depends_on "libzip"
   depends_on "ncurses"


### PR DESCRIPTION
I've contributed `libxls` brew, and I'm now making `sc-im` use it. This gives me easy Excel reading in the terminal.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
